### PR TITLE
use node20 as action runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -135,5 +135,5 @@ inputs:
     description: 'If provided, Synopsys Action will be using local network to download and execute bridge .'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR changes the action runtime from the deprecated `node16` to `node20`. Note that only the runtime is changed, not the version used for developing the action.

This PR closes #195